### PR TITLE
Updated Pane <AppIcon> implementation

### DIFF
--- a/src/MARCcat.js
+++ b/src/MARCcat.js
@@ -16,7 +16,7 @@ class MARCcat extends React.Component<Props, {}> {
     const { translate } = this.props;
     return (
       <Headline size="small" margin="medium" tag="h3">
-        {translate({ id:'ui-marccat.search.actionmenu.title' })}
+        {translate({ id: 'ui-marccat.search.actionmenu.title' })}
       </Headline>
     );
   };

--- a/src/components/Browse/Result/BrowseResults.js
+++ b/src/components/Browse/Result/BrowseResults.js
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { MultiColumnList, Pane, Paneset, Icon } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { Props, injectCommonProp } from '../../../core';
@@ -173,7 +174,7 @@ export class BrowseResults extends React.Component<Props, S> {
           defaultWidth="25%"
           paneTitle={<FormattedMessage id="ui-marccat.search.record.preview" />}
           paneSub={C.EMPTY_MESSAGE}
-          appIcon={{ app: C.META.ICON_TITLE }}
+          appIcon={<AppIcon app={C.META.ICON_TITLE} />}
           actionMenu={this.getActionMenu}
           dismissible
           onClose={() => {

--- a/src/components/Cataloguing/CreateMarcRecord.js
+++ b/src/components/Cataloguing/CreateMarcRecord.js
@@ -16,6 +16,7 @@ import {
   KeyValue,
   Icon
 } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import { reduxForm } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
 import _ from 'lodash';
@@ -251,7 +252,7 @@ export class CreateMarcRecord extends React.Component<P, {}> {
             defaultWidth="fullWidth"
             paneTitle={(bibliographicRecord) ? 'New Monograph' : 'New Monograph'}
             paneSub={(bibliographicRecord) ? 'id. ' + bibliographicRecord.id : 'id. ' + defaultTemplate.id}
-            appIcon={{ app: C.META.ICON_TITLE }}
+            appIcon={<AppIcon app={C.META.ICON_TITLE} />}
             actionMenu={ActionMenuTemplate}
             dismissible
             onClose={() => this.handleClose()}
@@ -268,7 +269,7 @@ export class CreateMarcRecord extends React.Component<P, {}> {
               defaultWidth="fullWidth"
               paneTitle={(bibliographicRecord) ? 'New Monograph' : 'New Monograph'}
               paneSub={(bibliographicRecord) ? 'id. ' + bibliographicRecord.id : 'id. ' + defaultTemplate.id}
-              appIcon={{ app: C.META.ICON_TITLE }}
+              appIcon={<AppIcon app={C.META.ICON_TITLE} />}
               actionMenu={ActionMenuTemplate}
               dismissible
               onClose={() => this.handleClose()}

--- a/src/components/Cataloguing/EditMarcRecord.js
+++ b/src/components/Cataloguing/EditMarcRecord.js
@@ -14,6 +14,7 @@ import {
   KeyValue,
   Icon
 } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import { ActionMenuTemplate, SingleCheckboxIconButton } from '../../lib';
 import { MarcLeader, FixedFields } from '.';
 import { injectCommonProp } from '../../core';
@@ -277,7 +278,7 @@ class EditMarcRecord extends React.Component {
             defaultWidth="fullWidth"
             paneTitle={(bibliographicRecord) ? 'New Monograph' : 'Edit Record'}
             paneSub={(bibliographicRecord) ? 'id. ' + bibliographicRecord.id : 'Edit Record id. '}
-            appIcon={{ app: C.META.ICON_TITLE }}
+            appIcon={<AppIcon app={C.META.ICON_TITLE} />}
             actionMenu={ActionMenuTemplate}
             dismissible
             onClose={() => this.handleClose()}
@@ -294,7 +295,7 @@ class EditMarcRecord extends React.Component {
               defaultWidth="fullWidth"
               dismissible
               paneTitle="Edit Record"
-              appIcon={{ app: C.META.ICON_TITLE }}
+              appIcon={<AppIcon app={C.META.ICON_TITLE} />}
               actionMenu={ActionMenuTemplate}
               paneSub={(bibliographicRecord) ? 'id. ' + bibliographicRecord.id : ''}
               onClose={this.handleClose}

--- a/src/components/Cataloguing/Marc/FixedFields.js
+++ b/src/components/Cataloguing/Marc/FixedFields.js
@@ -22,8 +22,8 @@ class FixedFields extends React.Component<P, {}> {
       expand007: false,
       expand008: false,
       fixedFields: [],
-      tag006Fields:[{}],
-      tag007Fields:[{}],
+      tag006Fields: [{}],
+      tag007Fields: [{}],
     };
   }
 

--- a/src/components/Cataloguing/Marc/VariableFields.js
+++ b/src/components/Cataloguing/Marc/VariableFields.js
@@ -13,7 +13,7 @@ import { SUBFILED_DELIMITER } from '../Utils/MarcUtils';
 class VariableFields extends React.Component<Props, {}> {
   constructor(props: Props) {
     super(props);
-    this.keys = { 'new' : ['enter'] };
+    this.keys = { 'new': ['enter'] };
     this.handlers = { 'new': this.handleAdd };
   }
 

--- a/src/components/Search/Result/components/AssociatedRecordPane.js
+++ b/src/components/Search/Result/components/AssociatedRecordPane.js
@@ -5,6 +5,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Pane, Icon } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import AssociatedBibDetails from '../AssociatedBibDetails';
 import { Props, injectCommonProp } from '../../../../core';
 import { ActionMenu } from '../../../../lib';
@@ -25,7 +26,7 @@ class AssociatedRecordPane extends React.Component<Props, {}> {
           defaultWidth="25%"
           paneTitle={<FormattedMessage id="ui-marccat.search.record.preview" />}
           paneSub={C.EMPTY_MESSAGE}
-          appIcon={{ app: C.META.ICON_TITLE }}
+          appIcon={<AppIcon app={C.META.ICON_TITLE} />}
           actionMenu={ActionMenu}
           dismissible
           onClose={onClose}

--- a/src/components/Search/Result/components/SearchResultPane.js
+++ b/src/components/Search/Result/components/SearchResultPane.js
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { Pane, Icon, MultiColumnList } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import { ActionMenu } from '../../../../lib';
 import { Props, injectCommonProp } from '../../../../core';
 import { resultsFormatter, columnMapper, columnWidthMapper } from '../../../../utils/Formatter';
@@ -72,9 +73,9 @@ class SearchResultPane extends React.Component<Props, {}> {
           padContent={(marcJSONRecords.length > 0) || isFetching}
           defaultWidth="fill"
           actionMenu={ActionMenu}
-          paneTitle={translate({ id:'ui-marccat.search.record' })}
+          paneTitle={translate({ id: 'ui-marccat.search.record' })}
           paneSub={(mergedRecord && mergedRecord.length > 0) ? message : messageNoContent}
-          appIcon={{ app: C.META.ICON_TITLE }}
+          appIcon={<AppIcon app={C.META.ICON_TITLE} />}
           firstMenu={firstMenu}
           lastMenu={lastMenu}
         >

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class MARCCatRouting extends React.Component<RoutingProps, {}> {
     store.dispatch({ type: ActionTypes.SETTINGS,
       data:
       {
-        defaultTemplate : {
+        defaultTemplate: {
           id: 408,
           name: 'Monograph'
         } } });

--- a/src/settings/components/DefaultTemplate.js
+++ b/src/settings/components/DefaultTemplate.js
@@ -45,7 +45,7 @@ class DefaultTemplate extends React.Component<P, {}> {
         label={
           <Icon icon="edit">
             {translate({
-              id:'ui-marccat.search.record.edit' })}
+              id: 'ui-marccat.search.record.edit' })}
           </Icon>
         }
       />

--- a/src/settings/components/LocalAuthorityRecords.js
+++ b/src/settings/components/LocalAuthorityRecords.js
@@ -23,7 +23,7 @@ class LocalAuthorityRecords extends React.Component<P, {}> {
         label={
           <Icon icon="edit">
             {translate({
-              id:'ui-marccat.search.record.edit' })}
+              id: 'ui-marccat.search.record.edit' })}
           </Icon>
         }
       />

--- a/src/settings/components/RecordOverlayRules.js
+++ b/src/settings/components/RecordOverlayRules.js
@@ -40,7 +40,7 @@ class RecordsOverlayRules extends React.Component<P, {}> {
         label={
           <Icon icon="edit">
             {translate({
-              id:'ui-marccat.search.record.edit' })}
+              id: 'ui-marccat.search.record.edit' })}
           </Icon>
         }
       />

--- a/src/settings/utils/ComonMenu.js
+++ b/src/settings/utils/ComonMenu.js
@@ -15,7 +15,7 @@ const rightMenu = ({ ...props }) => {
       label={
         <Icon icon="edit">
           {translate({
-            id:'ui-marccat.search.record.edit' })}
+            id: 'ui-marccat.search.record.edit' })}
         </Icon>
       }
     />);


### PR DESCRIPTION
In STCOM-473 we changed the AppIcon implementation for Pane's.

Instead of passing an object with the app icon data, we now simply pass an `<AppIcon>` directly.

**Note:** I changed 5 files but it seems my linter has updated some spaces in various files.

![image](https://user-images.githubusercontent.com/640976/52859403-e44bb680-312c-11e9-98ef-c1f54a0f0948.png)

Also, I am not able to run ui-marccat locally so I would appreciate if someone tested out these changes to be sure everything is working as intended.