### PR TITLE
publish mod descriptor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 
 buildNPM {
-  publishModDescriptor = false
+  publishModDescriptor = true
   runLint = true
   runSonarqube = true
   runTest = false


### PR DESCRIPTION
mod-marccat provides a compatible interface on it's master branch, so we can publish the ui-marrcat MD so that we can provide compatible snapshot artifacts needed for folio-snapshot. 