### PR TITLE
UICIRC-358: Prepend global CSS styles with the id of the module. 

### DIFF
--- a/src/shared/lib/Style/InputField.css
+++ b/src/shared/lib/Style/InputField.css
@@ -185,7 +185,8 @@
   max-height: 9em;
 }
 
-label {
+#duplicaRecordForm label,
+#marccat-module-display label {
   cursor: pointer;
   display: inline-block;
 }


### PR DESCRIPTION
It turned out that globally defined styles for labels messed up with styles for circulation editor rules. I have put this time both app root id and form id as this form happened to be used inside the modal which renders outside of the root when open.