### PR TITLE
add missing package.json files entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change history for ui-marccat
 
-## 2.0.0 (https://github.com/folio-org/ui-marccat/releases/tag/v2.0.0)
+## 2.1 (IN PROGRESS)
+
+* Adding translations and icons to `package.json` `files` array.
+* CHANGELOG cleanup
+
+## [2.0.0](https://github.com/folio-org/ui-marccat/releases/v2.0.0) (2019-10-09)
+[Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.3.0...v2.0.0)
+
 * Fix CRUD Cataloging.
 * Added cross-reference management in the browse search function
 * Add component for variable fields.
@@ -13,7 +20,9 @@
 * Fix search bugs.
 * Browse fix.
 
-## 1.3.0 (https://github.com/folio-org/ui-marccat/releases/tag/v1.3.0) (2019-04-10)
+## [1.3.0](https://github.com/folio-org/ui-marccat/releases/v1.3.0) (2019-04-10)
+[Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.2.0...v1.3.0)
+
 * CRUD Cataloging.
 * Add component for variable fields;
 * Improve data handling with Redux;
@@ -28,13 +37,17 @@
 * Fix search bugs.
 * Browse fix.
 
-## [1.2.0](https://github.com/folio-org/ui-marccat/releases/tag/v1.1.0) (2018-14-12)
+## [1.2.0](https://github.com/folio-org/ui-marccat/releases/v1.2.0) (2018-12-14)
+[Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.1.0...v1.2.0)
+
 * improvement search functionality, logic and UX side.
 * Start with cataloguing functionality.
 * Add base component for template management
 * Browse fix.
 
-## [1.1.0](https://github.com/folio-org/ui-marccat/releases/tag/v1.1.0) (2018-01-11)
+## [1.1.0](https://github.com/folio-org/ui-marccat/releases/v1.1.0)
+[Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.0.0...v1.1.0)
+
 * improvement search functionality, logic and UX side.
 * Handler record details panel.
 * Add panel for associated bib records.
@@ -43,7 +56,6 @@
 * Improvement logic and syntax.
 * Add traslation for record details results.
 
-## [1.0.0](https://github.com/folio-org/ui-marccat/releases/tag/v1.0.0) (2018-31-10)
-
+## [1.0.0](https://github.com/folio-org/ui-marccat/releases/v1.0.0)
 * First version to have a documented change-log.
 * Release first version of search functionality.

--- a/package.json
+++ b/package.json
@@ -83,11 +83,13 @@
     "react": "*"
   },
   "files": [
-    "README.md",
     "CHANGELOG.md",
-    "lib",
+    "README.md",
     "dist",
+    "icons",
+    "lib",
     "src",
+    "translations",
     "*.js.flow"
   ],
   "coverageReporters": [


### PR DESCRIPTION
When present, `package.json`'s `files` array acts as a filter, only
including the file-types which are explicitly listed when the package is
installed as a dependency. Without entries for `icons` and
`translations`, those elements were missing from the bundle when the
build was constructed outside the context of a workspace `ui-marccat`
had been cloned into.

See https://docs.npmjs.com/files/package.json#files for details