### PR TITLE
fix: default sortBy (now on record ID)

### DIFF
--- a/src/redux/epic/epics.js
+++ b/src/redux/epic/epics.js
@@ -35,7 +35,7 @@ function getJSON(url, headers) {
 export const searchEpic = (action$, store) => action$.ofType(ACTION.SEARCH)
   .switchMap((d) => concat$(
     of$(marccatActions.isfetchingSearchRequest(true, d.moreData)),
-    getJSON(buildUrl(store.getState(), ENDPOINT.MERGED_SEARCH_URL, `lang=ita&ml=170&qbib=${d.queryBib}&qauth=${d.queryAuth}&from=${d.from}&to=${d.to}&dpo=1&sortBy=${Selector.get(store, 'settings', 'sortType') || 4}&sortOrder=0`), getHeaders(store.getState()))
+    getJSON(buildUrl(store.getState(), ENDPOINT.MERGED_SEARCH_URL, `lang=ita&ml=170&qbib=${d.queryBib}&qauth=${d.queryAuth}&from=${d.from}&to=${d.to}&dpo=1&sortBy=${Selector.get(store, 'settings', 'sortType') || 54}&sortOrder=0`), getHeaders(store.getState()))
       .map(record => (
         marccatActions.fetchSearchEngineRecords(
           d.queryBib,


### PR DESCRIPTION
fix default sortBy in mergedSearch (now on record ID)