### PR TITLE
Fix Props in FieldEdit

### DIFF
--- a/src/components/Cataloguing/Marc/Form/VariableField/FieldEdit.js
+++ b/src/components/Cataloguing/Marc/Form/VariableField/FieldEdit.js
@@ -11,7 +11,7 @@ type Props = {
   cells: Array<Object>,
   columnMapping: Array<Object>,
   error: string | boolean,
-  field: PropTypes.string,
+  field: string,
   fieldComponents: Array<Object>,
   readOnlyFields: Array<string>,
   rowIndex: number,


### PR DESCRIPTION
Using `PropTypes.string` breaks the transpile in Babel 7