### PR TITLE
clean up peer-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for ui-marccat
 
-## 2.1 (IN PROGRESS)
+## 3.0 (IN PROGRESS)
 
 * Adding translations and icons to `package.json` `files` array.
 * CHANGELOG cleanup
+* Peer-dep cleanup: increment `@folio/stripes` to `^v4.0`, `react-intl` to `v4.5`.
 
 ## [2.0.0](https://github.com/folio-org/ui-marccat/releases/v2.0.0) (2019-10-09)
 [Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.3.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/marccat",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "FOLIO UI module for Cataloging",
   "repository": "folio-org/ui-marccat",
   "publishConfig": {
@@ -77,17 +77,15 @@
     "prop-types-extra": "^1.1.0",
     "react-final-form": "^6.3.0",
     "react-hot-loader": "^4.3.12",
-    "react-intl": "^4.5.1",
-    "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
     "redux-actions": "^2.2.1",
     "redux-observable": "^0.15.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^3.1.0",
+    "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-router": "^5.0.1",
-    "react-router-dom": "^5.0.1"
+    "react-intl": "^4.5.1",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
* increment `@folio/stripes` from `v3` to `v4`
* increment package version from `2.0.0` to `3.0.0` which should have
happened when `react-intl` was bumped to `v4`
* move `react-intl` to peerDeps
* remove `react-router` and `react-router-dom` as direct deps since they
are already correctly specified as peers
* resolve the conflicting versions of `react-router` to the peerDeps
version

The direct-dep on `react-intl` is preventing platform-complete#snapshot
from building at present because of a bug in the 4.7 line. Removing the
direct dep here means we can fix this with a single change in the
platform. Refs https://github.com/folio-org/platform-complete/pull/592