### PR TITLE
Fixing mirage config to run locally with `yarn start --mirage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Adding translations and icons to `package.json` `files` array.
 * CHANGELOG cleanup
-* Peer-dep cleanup: increment `@folio/stripes` to `^v5.0`, `@folio/stripes-core` to `v6.01`, `react-intl` to `v4.5`.
+* Peer-dep cleanup: increment `@folio/stripes` to `^v5.0`, `@folio/stripes-core` to `v6.0`, `react-intl` to `v4.5`.
 * Refactor from `bigtest/mirage` to `miragejs`.
 * Create buttons to separate the search by bibs/holds and authorities (UICAT-103)
 * Save and cancel buttons in the cataloguing worksheet like in Inventory (UICAT-104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Adding translations and icons to `package.json` `files` array.
 * CHANGELOG cleanup
-* Peer-dep cleanup: increment `@folio/stripes` to `^v4.0`, `react-intl` to `v4.5`.
+* Peer-dep cleanup: increment `@folio/stripes` to `^v5.0`, `@folio/stripes-core` to `v6.01`, `react-intl` to `v4.5`.
 * Refactor from `bigtest/mirage` to `miragejs`.
+* Add support for running `yarn start --mirage`.
 
 ## [2.0.0](https://github.com/folio-org/ui-marccat/releases/v2.0.0) (2019-10-09)
 [Full Changelog](https://github.com/folio-org/ui-marccat/compare/v1.3.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/marccat",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "FOLIO UI module for Cataloging",
   "repository": "folio-org/ui-marccat",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.13.0",
-    "@folio/stripes-core": "^5.0.1",
+    "@folio/stripes-core": "^6.0.0",
     "@folio/stripes-react-hotkeys": "^3.0.6",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.4",
@@ -86,7 +86,7 @@
     "redux-observable": "^0.15.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "react": "*",
     "react-intl": "^4.5.1",
     "react-router": "^4.3.1",

--- a/test/bigtest/network/boot.js
+++ b/test/bigtest/network/boot.js
@@ -1,6 +1,8 @@
 import startMirage from '@folio/stripes-core/test/bigtest/network/start';
 import mirageOptions from '.';
 
+mirageOptions.serverType = 'miragejs';
+
 /**
 * Start mirage to handle requests in development and production. Note
 * that this file will _not_ be include in the build at all if mirage


### PR DESCRIPTION
- Previously was crashing with error `this.associationKeys.has is not a function`
- Also bumping up `stripes` and `stripes-core` versions to avoid `react-intl` errors.